### PR TITLE
Hack in simple backup script for InfluxDB v0.8.x.

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Installed to root's crotab with schedule:
+# 20 15 * * * /home/ec2-user/pyden/backup.sh
+
+START=$(/bin/date +%s)
+/sbin/service influxdb stop
+/bin/tar -cjf /tmp/den-shared.tbz /opt/influxdb/shared
+/sbin/service influxdb start
+echo "InfluxDB down during archive creation for" $(($(/bin/date +%s) - $START)) "seconds"
+
+UPLOAD_START=$(/bin/date +%s)
+/usr/bin/aws s3 cp /tmp/den-shared.tbz s3://den.k20e.com
+echo "Upload completed in" $(($(/bin/date +%s) - $UPLOAD_START)) "seconds"
+echo "Backup completed in" $(($(/bin/date +%s) - $START)) "seconds"


### PR DESCRIPTION
This is a much simpler hack to dump the state of the database than what was started on in #3.  Just a `cron` job and :four_leaf_clover:.
